### PR TITLE
JWS: allow empty payload

### DIFF
--- a/src/jwt.js
+++ b/src/jwt.js
@@ -7,6 +7,10 @@ const SUPPORTED_ALG = Object.keys(SignatureAlgorithms.sign);
 
 class Token {
 	static stringify_utf8(json) {
+		if(typeof json === 'string') {
+			return json;
+		}
+
 		return Buffer.from(JSON.stringify(json)).toString('utf8');
 	}
 

--- a/test/jwt.js
+++ b/test/jwt.js
@@ -71,6 +71,22 @@ describe('Tokens', () => {
 			expect(token).to.be.eql(example_token);
 		});
 
+		it('An empty payload needs to be respected', () => {
+			DateFreeze.freeze(now);
+
+			const { b64_payload: b64_empty_obj } = token_generator.build({
+				payload: {}
+			});
+
+			const { b64_payload: b64_empty_str } = token_generator.build({
+				payload: ''
+			});
+
+			// Note that signatures are not the same
+			expect(Buffer.from(b64_empty_obj, 'base64url').toString('utf8')).to.be.eql('{}');
+			expect(Buffer.from(b64_empty_str, 'base64url').toString('utf8')).to.be.eql('');
+		});
+
 		it('Should generate a known token with HS256 + custom header values', () => {
 			DateFreeze.freeze(now);
 


### PR DESCRIPTION
TODO:
* check if this is conform to the Spec, jwt.io seems to think not and expects `e30` at least